### PR TITLE
fix: conditional syntax errors in `steps[*].if`

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -134,13 +134,13 @@ runs:
 
 
     - name: Start the Pongo environment
-      if: ${{ inputs.start_environment }} == "true"
+      if: ${{ inputs.start_environment == 'true' }}
       run: pongo up
       shell: bash
 
 
     - name: Build the Pongo test image for Kong version ${{ inputs.kong_version }}
-      if: ${{ inputs.build_image }} == "true"
+      if: ${{ inputs.build_image == 'true' }}
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
       run: pongo build


### PR DESCRIPTION
The issue was with the conditional statements for `start_environment` and `build_image` inputs. 
