### PR TITLE
feat(*): add support for github action cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This action will install and configure Pongo for a specific version of [Kong Gat
 | `pongo_version` | `"latest"` | yes | The Pongo version to use for testing. This can be a Pongo version tag or branch name (use `"master"` for bleeding-edge). A special case is `"latest"` which will use the latest released version. |
 | `start_environment` | `"true"` | no | By default the test environment will be spun up. Set this value to `"false"` to not start the test environment. |
 | `build_image` | `"true"` | no | By default the test image will be build. Set this value to `"false"` to not build the test image. |
+| `cache` |  | no | If set, cache the Pongo test image using the given docker cache type to avoid rebuilding the image at each run. Can only be set to `github` for now. |
 | `license` | value of env var `KONG_LICENSE_DATA` | no | The Kong license. This is only required if you are testing a plugin against an Enterprise version of the Kong Gateway. </br>**Note**: make sure to pass it to Github as a secret! |
 
 

--- a/action.yaml
+++ b/action.yaml
@@ -58,7 +58,12 @@ inputs:
       The token to clone the `kong-ee` git repo for `dev-ee` testing.
     required: false
 
-
+  cache:
+    description: >
+      If set, cache the Pongo test image using the given cache type
+      to avoid rebuilding the image at each run.
+      Can only be set to `github` for now.
+    required: false
 
 runs:
   using: "composite"
@@ -137,6 +142,35 @@ runs:
       if: ${{ inputs.start_environment == 'true' }}
       run: pongo up
       shell: bash
+
+
+    # The native docker driver does not support cache from/to GitHub Actions Cache
+    # so we need to set up Buildx when GitHub cache is enabled
+    - name: Set up Docker Buildx to have GitHub Actions Cache support
+      if: ${{ inputs.cache == 'github' }}
+      uses: docker/setup-buildx-action@v3
+      with:
+        install: true
+
+
+    - name: Expose environment variables required by GitHub Actions Cache
+      if: ${{ inputs.cache == 'github' }}
+      uses: actions/github-script@v7
+      with:
+        # gha cache type requires an url and a token parameter, they will be automatically
+        # set from ACTIONS_CACHE_URL and ACTIONS_RUNTIME_TOKEN if present
+        # These variables are automatically set by GitHub Actions but they are only available
+        # for javascript actions, so we need to re-export them as environment variables
+        # We export the DOCKER_BUILD_EXTRA_ARGS similarly to be consistent
+        script: |
+          core.exportVariable('ACTIONS_CACHE_URL', process.env['ACTIONS_CACHE_URL'])
+          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env['ACTIONS_RUNTIME_TOKEN'])
+          core.exportVariable('DOCKER_BUILD_EXTRA_ARGS', process.env['DOCKER_BUILD_EXTRA_ARGS'])
+      env:
+        DOCKER_BUILD_EXTRA_ARGS: >
+          --output=type=docker
+          --cache-from=type=gha,scope=kong-pongo-${{ inputs.pongo_version }}:${{ inputs.kong_version }}
+          --cache-to=type=gha,mode=min,scope=kong-pongo-${{ inputs.pongo_version }}:${{ inputs.kong_version }},ignore-error=true
 
 
     - name: Build the Pongo test image for Kong version ${{ inputs.kong_version }}


### PR DESCRIPTION
Add a new option to enable the usage of GitHub Action Cache to cache the Kong test image and avoid rebuilding it at each run.

Note that it takes a bit longer on the first run as the layer needs to be exported. It then divides by 2 the execution time of the action for subsequent executions.

This linked to issue https://github.com/Kong/kong-pongo-action/issues/3 (but enable github action cache and not local cache) and requires https://github.com/Kong/kong-pongo/pull/655.